### PR TITLE
Add find by tags functionality to Find command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'jacoco'
 }
 
-mainClassName = 'seedu.address.Main'
+mainClassName = 'tutortrack.Main'
 
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -155,6 +155,22 @@ Classes used by multiple components are in the `seedu.address.commons` package.
 
 This section describes some noteworthy details on how certain features are implemented.
 
+### Find feature
+
+The find feature allows users to search for persons by name (default) or by tags (with `t/` prefix).
+
+#### Implementation
+
+The find mechanism is implemented using predicates:
+* `NameContainsKeywordsPredicate` - filters persons whose names match the keywords
+* `TagContainsKeywordsPredicate` - filters persons whose tags match the keywords
+
+The `FindCommandParser` detects the presence of the `t/` prefix using `ArgumentTokenizer`:
+* If `t/` prefix is present, it creates a `FindCommand` with `TagContainsKeywordsPredicate`
+* If `t/` prefix is absent, it creates a `FindCommand` with `NameContainsKeywordsPredicate` (default behavior)
+
+Both predicates implement `Predicate<Person>` and use case-insensitive full-word matching via `StringUtil.containsWordIgnoreCase()`.
+
 ### \[Proposed\] Undo/redo feature
 
 #### Proposed Implementation
@@ -379,7 +395,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case ends.
 
-**Use case: find a student by name**
+**Use case: find a student by name or tag**
 
 **MSS**
 
@@ -524,6 +540,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 * **Person**: A contact entity stored in the address book with fields such as name and phone.
 * **Tag**: A label attached to a person for categorisation or filtering.
+* **Predicate**: A functional interface that tests a condition on a `Person` object, used for filtering the person list.
 
 * **Parser**: Converts raw user input into specific `Command` objects.
 * **Command**: An object created by the parser that encapsulates a user action to be executed by `Logic`.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -110,15 +110,16 @@ Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
 *  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
 
-### Locating persons by name: `find`
+### Locating persons: `find`
 
-Finds persons whose names contain any of the given keywords.
+Finds persons whose names or tags contain any of the given keywords.
 
-Format: `find KEYWORD [MORE_KEYWORDS]`
+Format: `find KEYWORD [MORE_KEYWORDS]` OR `find t/TAG_KEYWORD [MORE_TAG_KEYWORDS]`
 
 * The search is case-insensitive. e.g `hans` will match `Hans`
 * The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
-* Only the name is searched.
+* By default (without `t/` prefix), only the name is searched.
+* With `t/` prefix, only tags are searched.
 * Only full words will be matched e.g. `Han` will not match `Hans`
 * Persons matching at least one keyword will be returned (i.e. `OR` search).
   e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
@@ -127,6 +128,8 @@ Examples:
 * `find John` returns `john` and `John Doe`
 * `find alex david` returns `Alex Yeoh`, `David Li`<br>
   ![result for 'find alex david'](images/findAlexDavidResult.png)
+* `find t/friends` returns all persons tagged with `friends`
+* `find t/friends colleagues` returns all persons tagged with either `friends` or `colleagues`
 
 ### Deleting a person : `delete`
 
@@ -195,6 +198,6 @@ Action | Format, Examples
 **Clear** | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
 **Edit** | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
-**Find** | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
+**Find** | `find KEYWORD [MORE_KEYWORDS]` OR `find t/TAG_KEYWORD [MORE_TAG_KEYWORDS]`<br> e.g., `find James Jake`, `find t/friends`
 **List** | `list`
 **Help** | `help`

--- a/src/main/java/tutortrack/logic/commands/FindCommand.java
+++ b/src/main/java/tutortrack/logic/commands/FindCommand.java
@@ -2,27 +2,31 @@ package tutortrack.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.Predicate;
+
 import tutortrack.commons.util.ToStringBuilder;
 import tutortrack.logic.Messages;
 import tutortrack.model.Model;
-import tutortrack.model.person.NameContainsKeywordsPredicate;
+import tutortrack.model.person.Person;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Finds and lists all persons in address book whose name or tags contain any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names or tags contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Parameters: KEYWORD [MORE_KEYWORDS]... OR t/TAG_KEYWORD [MORE_TAG_KEYWORDS]...\n"
+            + "Examples:\n"
+            + COMMAND_WORD + " alice bob charlie (searches by name)\n"
+            + COMMAND_WORD + " t/friend (searches by tag)";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate<Person> predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(Predicate<Person> predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/tutortrack/logic/parser/FindCommandParser.java
+++ b/src/main/java/tutortrack/logic/parser/FindCommandParser.java
@@ -1,12 +1,15 @@
 package tutortrack.logic.parser;
 
 import static tutortrack.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tutortrack.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
+import java.util.List;
 
 import tutortrack.logic.commands.FindCommand;
 import tutortrack.logic.parser.exceptions.ParseException;
 import tutortrack.model.person.NameContainsKeywordsPredicate;
+import tutortrack.model.person.TagContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -25,6 +28,21 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
+        // Check if the input contains the tag prefix
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
+
+        // If tag prefix is present and has values, search by tags
+        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            String tagKeywordsString = argMultimap.getValue(PREFIX_TAG).get();
+            if (tagKeywordsString.isEmpty()) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+            List<String> tagKeywords = Arrays.asList(tagKeywordsString.split("\\s+"));
+            return new FindCommand(new TagContainsKeywordsPredicate(tagKeywords));
+        }
+
+        // Otherwise, search by name (default behavior)
         String[] nameKeywords = trimmedArgs.split("\\s+");
 
         return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));

--- a/src/main/java/tutortrack/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/tutortrack/model/person/TagContainsKeywordsPredicate.java
@@ -1,0 +1,46 @@
+package tutortrack.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import tutortrack.commons.util.StringUtil;
+import tutortrack.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code Tag} matches any of the keywords given.
+ */
+public class TagContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public TagContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> person.getTags().stream()
+                        .anyMatch(tag -> StringUtil.containsWordIgnoreCase(tag.tagName, keyword)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof TagContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        TagContainsKeywordsPredicate otherTagContainsKeywordsPredicate = (TagContainsKeywordsPredicate) other;
+        return keywords.equals(otherTagContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}
+

--- a/src/test/java/tutortrack/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/tutortrack/logic/parser/FindCommandParserTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import tutortrack.logic.commands.FindCommand;
 import tutortrack.model.person.NameContainsKeywordsPredicate;
+import tutortrack.model.person.TagContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -29,6 +30,23 @@ public class FindCommandParserTest {
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validTagArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FindCommand expectedFindCommand =
+                new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList("friends", "colleagues")));
+        assertParseSuccess(parser, " t/friends colleagues", expectedFindCommand);
+
+        // single tag keyword
+        expectedFindCommand = new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList("friends")));
+        assertParseSuccess(parser, " t/friends", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_emptyTagValue_throwsParseException() {
+        assertParseFailure(parser, " t/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
 }

--- a/src/test/java/tutortrack/model/person/TagContainsKeywordsPredicateTest.java
+++ b/src/test/java/tutortrack/model/person/TagContainsKeywordsPredicateTest.java
@@ -1,0 +1,89 @@
+package tutortrack.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import tutortrack.testutil.PersonBuilder;
+
+public class TagContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        TagContainsKeywordsPredicate firstPredicate = new TagContainsKeywordsPredicate(firstPredicateKeywordList);
+        TagContainsKeywordsPredicate secondPredicate = new TagContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TagContainsKeywordsPredicate firstPredicateCopy = new TagContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_tagContainsKeywords_returnsTrue() {
+        // One keyword
+        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Collections.singletonList("friends"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("friends").build()));
+
+        // Multiple keywords
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("friends", "colleagues"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("friends", "colleagues").build()));
+
+        // Only one matching keyword
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("friends", "family"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("friends", "colleagues").build()));
+
+        // Mixed-case keywords
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("FrIeNdS", "CoLlEaGuEs"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("friends", "colleagues").build()));
+    }
+
+    @Test
+    public void test_tagDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withTags("friends").build()));
+
+        // Non-matching keyword
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("family"));
+        assertFalse(predicate.test(new PersonBuilder().withTags("friends", "colleagues").build()));
+
+        // Keywords match name, but does not match tag
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").withTags("friends").build()));
+
+        // Person with no tags
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("friends"));
+        assertFalse(predicate.test(new PersonBuilder().withTags().build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(keywords);
+
+        String expected = TagContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}
+


### PR DESCRIPTION
The current find command only searches persons by name, limiting search flexibility for tutors who want to search up students with important tags.

Users who tag their contacts cannot easily filter and find persons based on those tags, making tag organization less useful.

Let's enhance the find command to support tag-based searching: 

- Create TagContainsKeywordsPredicate to filter persons by tags *Update FindCommandParser to detect t/ prefix for tag search mode 
- Modify FindCommand to accept generic Predicate for flexibility *Add tests for tag search functionality
- Update User Guide and Developer Guide with examples and implementation details
- Using a separate predicate class maintains consistency with the existing NameContainsKeywordsPredicate pattern and allows FindCommand to remain flexible for future search enhancements.

The implementation uses ArgumentTokenizer to detect the t/ prefix defaulting to name search when absent. This makes it quicker when users want to search for names

Also fixed build.gradle mainClassName from seedu.address.Main to tutortrack.Main to resolve application startup error.
