### PR TITLE
Improve error handling for find command

### DIFF
--- a/src/main/java/tutortrack/logic/parser/FindCommandParser.java
+++ b/src/main/java/tutortrack/logic/parser/FindCommandParser.java
@@ -51,6 +51,17 @@ public class FindCommandParser implements Parser<FindCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
                 PREFIX_TAG, PREFIX_DAYTIME, PREFIX_SUBJECTLEVEL);
 
+        // Check if any prefix is present
+        boolean hasPrefixes = argMultimap.getValue(PREFIX_TAG).isPresent()
+                || argMultimap.getValue(PREFIX_DAYTIME).isPresent()
+                || argMultimap.getValue(PREFIX_SUBJECTLEVEL).isPresent();
+
+        // If a prefix is present, preamble should be empty
+        if (hasPrefixes && !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+
         // If day/time prefix is present, search by day and sort by time
         if (argMultimap.getValue(PREFIX_DAYTIME).isPresent()) {
             String dayKeyword = extractNonEmptyValue(argMultimap, PREFIX_DAYTIME);

--- a/src/test/java/tutortrack/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/tutortrack/logic/parser/FindCommandParserTest.java
@@ -105,4 +105,28 @@ public class FindCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE);
         assertParseFailure(parser, " s/ ", expectedMessage);
     }
+
+    @Test
+    public void parse_preambleWithTagPrefix_throwsParseException() {
+        // Should reject when both preamble and tag prefix are present
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "john t/exams", expectedMessage);
+        assertParseFailure(parser, "alice bob t/friends", expectedMessage);
+    }
+
+    @Test
+    public void parse_preambleWithDayPrefix_throwsParseException() {
+        // Should reject when both preamble and day prefix are present
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "alice d/Monday", expectedMessage);
+        assertParseFailure(parser, "john doe d/Friday", expectedMessage);
+    }
+
+    @Test
+    public void parse_preambleWithSubjectPrefix_throwsParseException() {
+        // Should reject when both preamble and subject prefix are present
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "bob s/P4-Math", expectedMessage);
+        assertParseFailure(parser, "alice s/S2-Science", expectedMessage);
+    }
 }


### PR DESCRIPTION
Previously, FindCommandParser silently ignored the preamble when a prefix was present (e.g., "find john t/exams" would ignore "john" and only search for tags). This fix adds validation to reject commands that have both a preamble and a prefix, following the same pattern used in AddCommandParser.

Let's
- Add preamble validation in FindCommandParser.parse()
- Add test cases for preamble with tag, day, and subject prefixes

This ensures that user receives error messages instead of expecting the search to succeed.

fixes #215 