### PR TITLE
Fix duplication contact logic

### DIFF
--- a/src/main/java/tutortrack/model/person/Person.java
+++ b/src/main/java/tutortrack/model/person/Person.java
@@ -151,9 +151,24 @@ public class Person {
             return true;
         }
 
-        return otherPerson != null
-                && otherPerson.getName().equals(getName());
+        if (otherPerson == null) {
+            return false;
+        }
+
+        // Consider persons the same if they share the same name (case-insensitive, trimmed)
+        // and the same self contact (NOK contact is ignored for duplication checks).
+        String thisName = this.getName() == null ? null : this.getName().toString().trim();
+        String otherName = otherPerson.getName() == null ? null : otherPerson.getName().toString().trim();
+
+        Phone thisSelf = this.getSelfContact();
+        Phone otherSelf = otherPerson.getSelfContact();
+
+        boolean sameName = thisName != null && otherName != null && thisName.equalsIgnoreCase(otherName);
+        boolean sameSelfContact = thisSelf != null && otherSelf != null && thisSelf.equals(otherSelf);
+
+        return sameName && sameSelfContact;
     }
+
 
     /**
      * Removes a lesson plan entry on the specified date if it exists.

--- a/src/test/java/tutortrack/model/person/PersonTest.java
+++ b/src/test/java/tutortrack/model/person/PersonTest.java
@@ -36,27 +36,42 @@ public class PersonTest {
         // null -> returns false
         assertFalse(ALICE.isSamePerson(null));
 
-        // same name, all other attributes different -> returns true
+        // same name (case-insensitive, trimmed), same self contact, other attributes different -> returns true
         Person editedAlice = new PersonBuilder(ALICE)
-                                     .withSelfContact(VALID_CONTACT_BOB)
-                                     .withNokContact(VALID_NOK_CONTACT_BOB)
-                                     .withAddress(VALID_ADDRESS_BOB)
-                                     .withTags(VALID_TAG_HUSBAND)
-                                     .build();
+                                    .withSelfContact(ALICE.getSelfContact().toString()) // same self contact
+                                    .withNokContact(VALID_NOK_CONTACT_BOB)
+                                    .withAddress(VALID_ADDRESS_BOB)
+                                    .withTags(VALID_TAG_HUSBAND)
+                                    .build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
-        // different name, all other attributes same -> returns false
-        editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        // same name but different self contact -> returns false
+        editedAlice = new PersonBuilder(ALICE)
+                              .withSelfContact(VALID_CONTACT_BOB)
+                              .build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
-        Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        // different name but same self contact -> returns false
+        editedAlice = new PersonBuilder(ALICE)
+                              .withName(VALID_NAME_BOB)
+                              .withSelfContact(ALICE.getSelfContact().toString())
+                              .build();
+        assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name has trailing spaces, all other attributes same -> returns false
+        // name differs only in case, same self contact -> returns true (case-insensitive)
+        Person editedBob = new PersonBuilder(BOB)
+                                  .withName(VALID_NAME_BOB.toLowerCase())
+                                  .withSelfContact(BOB.getSelfContact().toString())
+                                  .build();
+        assertTrue(BOB.isSamePerson(editedBob));
+
+        // name has trailing spaces, same self contact -> returns true (trimmed before compare)
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        editedBob = new PersonBuilder(BOB)
+                          .withName(nameWithTrailingSpaces)
+                          .withSelfContact(BOB.getSelfContact().toString())
+                          .build();
+        assertTrue(BOB.isSamePerson(editedBob));
     }
 
     @Test


### PR DESCRIPTION
Only considered as duplicate when it has same name(case-insensitive) and same contact